### PR TITLE
fix: classify Jira attachment vault writes [Codex]

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,13 +8,13 @@ default_stages: [pre-commit]
 # This is a template for connector pre-commit hooks
 repos:
   - repo: https://github.com/compilerla/conventional-pre-commit
-    rev: v4.1.0
+    rev: v4.4.0
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
         args: [--verbose]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer
@@ -27,13 +27,13 @@ repos:
       - id: check-json
       - id: check-yaml
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.7
+    rev: v0.15.22
     hooks:
       - id: ruff
         args: [ "--fix", "--unsafe-fixes"] # Allow unsafe fixes (ruff pretty strict about what it can fix)
       - id: ruff-format
   - repo: https://github.com/djlint/djLint
-    rev: v1.36.4
+    rev: v1.40.8
     hooks:
       - id: djlint-reformat-django
       - id: djlint-django
@@ -43,12 +43,12 @@ repos:
       - id: soar-app-linter
         args: ["--single-repo", "--message-level", "error"]
   - repo: https://github.com/hukkin/mdformat
-    rev: 0.7.22
+    rev: 1.0.0
     hooks:
       - id: mdformat
         exclude: "release_notes/.*"
   - repo: https://github.com/returntocorp/semgrep
-    rev: v1.136.0
+    rev: v1.165.0
     hooks:
       - id: semgrep
         additional_dependencies: ["setuptools==81.0.0"]
@@ -61,7 +61,7 @@ repos:
         exclude: "README.md"
   # Central hooks
   - repo: https://github.com/phantomcyber/dev-cicd-tools
-    rev: v2.1.4
+    rev: v2.2.3
     hooks:
       - id: build-docs
         language: python

--- a/NOTICE
+++ b/NOTICE
@@ -415,4 +415,3 @@ Copyright 2014 Ian Cordasco, Cory Benfield
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
-

--- a/README.md
+++ b/README.md
@@ -565,8 +565,8 @@ summary.total_objects_successful | numeric | | 1 |
 
 Gets specific attachments from a Jira Ticket (issue)
 
-Type: **investigate** <br>
-Read only: **True**
+Type: **generic** <br>
+Read only: **False**
 
 The function will store specific attachments from a given Jira ticket inside the vault.
 

--- a/jira.json
+++ b/jira.json
@@ -1424,9 +1424,9 @@
             "action": "get attachments",
             "description": "Gets specific attachments from a Jira Ticket (issue)",
             "verbose": "The function will store specific attachments from a given Jira ticket inside the vault.",
-            "type": "investigate",
+            "type": "generic",
             "identifier": "get_attachments",
-            "read_only": true,
+            "read_only": false,
             "parameters": {
                 "id": {
                     "description": "The key of the Jira issue",

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Classify the get attachments action as state-changing because it writes downloaded files to the SOAR vault.


### PR DESCRIPTION
## Summary

- Marks `get attachments` as a generic, non-read-only action because successful execution writes downloaded files into the SOAR vault.
- Refreshes pre-commit tooling separately to the current shared hook release.

## Tracking

- PAPP: PAPP-37954
- PSAAS: PSAAS-31569

## Validation

- Full `pre-commit run --all-files`: passed.
- Python compilation and JSON parsing: passed.

Written and implemented by Codex.